### PR TITLE
Update Mbit_IR.cpp

### DIFF
--- a/Mbit_IR.cpp
+++ b/Mbit_IR.cpp
@@ -8,7 +8,7 @@ modified by chengengyue
 #include <vector>
 #include "ReceiverIR.h"
 using namespace pxt;
-typedef vector<Action> vA;
+ typedef vector<Action> vA;
 
 enum class RemoteButton {
     Power = 0x0,


### PR DESCRIPTION
With reference to https://github.com/microsoft/pxt-microbit/issues/4812, there will be issue when comiple the program in Makecode Online Editor. The solution is to add a single space in front of typedef.
